### PR TITLE
feat: add github workflow and script to update synapse tables 

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,26 @@
+# GitHub Actions Scripts
+
+This directory contains scripts designed specifically for use with GitHub Actions workflows. These scripts are intended to be run automatically as part of the CI/CD pipeline and should not be run manually.
+
+## Overview
+
+The scripts in this directory automate various tasks related to testing, deployment, and maintenance within GitHub Actions. Each script is triggered by a corresponding YAML workflow file in `.github/workflows/`.
+
+## Script List
+
+### Example Script: `update_synapse_tables.py`
+
+- **Description**: Updates Synapse tables based on recent changes. This script is triggered automatically by changes in specific files and is not intended for manual use.
+
+- **Usage**: This script is called within a GitHub Actions workflow. See file `project_data_change.yml`.
+
+- **Trigger Conditions**: This workflow runs when there’s a `push` to the `main` branch that includes changes to any `.tsv` files in the `project/data/` directory.
+
+- **How it Works**:
+  1. **Changed Files Check**: The workflow identifies changes in `.tsv` files within the `project/data/` directory using the associated `sha` of the `push`. This way, the action can be rerun manually and update the tables if it fails.
+  2. **Run Conditions**: If relevant `.tsv` files are changed, the list of changed files is passed to the `update_synapse_tables.py` script. The files are passed as  paths (ex: `["project/data/DataStandardOrTool.tsv", "project/data/Organization.tsv"]`)
+  3. **Script Execution**: The script processes these files to update the corresponding tables in Synapse, using the Synapse authentication token stored in GitHub Secrets (`SYNAPSE_AUTH_TOKEN`) for secure access. It establishes a connection to synapse, takes snapshots of the tables it is updating, deletes all of the rows for those tables, and repopulates them using the tsv.
+
+  **Note:** This script processes the tsv files and turns the rows into a list of entries to add to the database. It assumes the first line of the tsv is the header file, so that gets ignored. Please make sure to update this script if the header line is ever removed.
+
+  **Important note:** This script will not work if the schema has changed. This includes added columns, deleted columns, or if columns have changed order. If the schema has changed, update and run the `scripts/modify_synapse_schema.py` script to update the table schemas in Synapse.

--- a/.github/scripts/update_synapse_tables.py
+++ b/.github/scripts/update_synapse_tables.py
@@ -1,0 +1,84 @@
+import csv
+import sys
+from synapseclient import Synapse, Table
+import os
+
+
+# the paths detected as changes from the "Get changed files" job mapped to their corresponding synapse table ids
+PATHS_TO_IDS = {
+    "project/data/DataStandardOrTool.tsv": "syn63096833",
+    "project/data/DataSubstrate.tsv": "syn63096834",
+    "project/data/DataTopic.tsv": "syn63096835",
+    "project/data/Organization.tsv": "syn63096836",
+    "project/data/UseCase.tsv": "syn63096837",
+}
+
+
+def delete_table_rows(syn: Synapse, table_id: str) -> None:
+    """Delete all the rows for a table, given its id
+    :param syn: synapse client
+    :param table_id: table id to delete rows for
+    """
+    print("Deleting rows from table {table_id}")
+    results = syn.tableQuery(f"select * from {table_id}")
+    syn.delete(results)
+    print("Finished deleting rows")
+
+
+def get_rows_from_tsv(file_path: str):
+    """Read a TSV file and return a list of lists, where each inner list represents a row.
+    NOTE: The first row of the file is expected to be the headers, which is skipped
+    :param file_path: path to tsv file
+    :return: list of lists representing rows of the tsv file"""
+    rows = []
+    with open(file_path, mode="r", newline="", encoding="utf-8") as tsv_file:
+        reader = csv.reader(tsv_file, delimiter="\t")
+        # Skip the header row
+        next(reader)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def populate_table(syn: Synapse, update_file: str, table_id: int) -> None:
+    """Populate the table with updated data
+    :param syn: synapse client
+    :param update_file: path for tsv file containing data to populate the table
+    :param table_id: id for table to populate
+    """
+    rows_to_add = get_rows_from_tsv(update_file)
+    print(f"Populating table for file: {update_file}")
+    table = syn.store(Table(table_id, rows_to_add))
+    print("Finished populating table")
+
+
+def main():
+    try:
+        changed_files = sys.argv[1:]
+
+        if not changed_files:
+            print("No relevant files passed to the script.")
+            return
+
+        print("Creating synapse client...")
+        syn = Synapse()
+        auth_token = os.getenv("SYNAPSE_AUTH_TOKEN")
+        if not auth_token:
+            raise ValueError("SYNAPSE_AUTH_TOKEN environment variable is not set")
+        print("Signing in...")
+        syn.login(authToken=auth_token)
+
+        for changed_file in changed_files:
+            table_id = PATHS_TO_IDS.get(changed_file)
+            print(f"Creating snapshot for table {changed_file}")
+            syn.create_snapshot_version(table_id)
+            delete_table_rows(syn, table_id)
+            populate_table(syn, changed_file, table_id)
+
+    except Exception as e:
+        print(f"An error occurred when trying to update synapse tables: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/project_data_change.yml
+++ b/.github/workflows/project_data_change.yml
@@ -1,0 +1,49 @@
+name: "Run script to update synapse tables"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'project/data/*.tsv'
+
+jobs:
+  update_synapse_tables:
+    name: Run script to update synapse tables with data changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install synapseclient
+
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Get changed files
+        id: changes
+        run: |
+          CHANGED_FILES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.files[].filename' | grep 'project/data/')
+          CHANGED_FILES=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+          echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
+          echo "Files changed: $CHANGED_FILES"
+
+      - name: Run script to update synapse tables
+        run: |
+          if [ -n "${{ env.CHANGED_FILES }}" ]; then
+            python3 .github/scripts/update_synapse_tables.py ${{ env.CHANGED_FILES }}
+          else
+            echo "No relevant TSV files changed."
+          fi
+        env:
+          SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,54 @@
+# Project Scripts
+
+This directory contains manually executed scripts used for managing and interacting with the project's data standards and tools. These scripts are not meant to be run as part of automated updates (such as GitHub Actions) but can be executed locally when needed.
+
+## Overview
+
+The scripts in this folder are designed to:
+
+- Define and manage Synapse table schemas.
+- Perform one-time or occasional tasks related to database setup and maintenance.
+
+**Note:** These scripts are intended to be run manually and are not part of the project's automated CI/CD pipeline.
+
+## Setup
+
+To run these scripts, you’ll need to install the required dependencies. This can be done by installing the dependencies listed in the requirements-scripts.txt file.
+
+1. **Install Dependencies**
+
+    In your terminal, navigate to the project root and install the requirements with:
+
+    ```shell
+    pip install -r scripts/requirements-scripts.txt
+    ```
+
+2. **Environment Variables**
+
+    Ensure you have the necessary authentication set up for Synapse access. You can set up your Personal Access Token following the documentation [here](https://help.synapse.org/docs/Managing-Your-Account.2055405596.html#ManagingYourAccount-PersonalAccessTokens).
+
+    Once you have your access token, export it like below:
+
+    ```shell
+    export SYNAPSE_AUTH_TOKEN=paste_your_token_here
+    ```
+
+## Usage
+
+Each script is intended to be run individually. Here’s how to use them:
+
+### Example Script: table_schema_setup.py
+
+**Description:** Sets up and manages table schemas in Synapse, defining the column structure for each table.
+
+**Run:**
+
+```bash
+python scripts/table_schema_setup.py
+```
+
+#### Requirements
+
+This script requires Synapse authentication (replace `auth_token` in the script with your actual token or set it as an environment variable).
+
+**Note:** Ensure you have a Synapse account with appropriate permissions before running this script.

--- a/scripts/modify_synapse_schema.py
+++ b/scripts/modify_synapse_schema.py
@@ -1,0 +1,175 @@
+"""A python script for creating/updating B2AI standards explorer table schemas in synapse
+This script should be updated and rerun when the schema of the tables must be updated"""
+
+import os
+from synapseclient import Synapse, Table, Column, Schema
+from enum import Enum
+
+
+# Possible column names for the tables
+class ColumnName(Enum):
+    ID = "id"
+    CATEGORY = "category"
+    NAME = "name"
+    DESCRIPTION = "description"
+    CONTRIBUTOR_NAME = "contributor_name"
+    CONTRIBUTOR_GITHUB_NAME = "contributor_github_name"
+    CONTRIBUTOR_ORCID = "contributor_orcid"
+    COLLECTION = "collection"
+    CONCERNS_DATA_TOPIC = "concerns_data_topic"
+    PURPOSE_DETAIL = "purpose_detail"
+    SUBCLASS_OF = "subclass_of"
+    URL = "url"
+    IS_OPEN = "is_open"
+    REQUIRES_REGISTRATION = "requires_registration"
+    EDAM_ID = "edam_id"
+    MESH_ID = "mesh_id"
+    NCIT_ID = "ncit_id"
+    RELATED_TO = "related_to"
+    METADATA_STORAGE = "metadata_storage"
+    FILE_EXTENSIONS = "file_extensions"
+    LIMITATIONS = "limitations"
+    CONTRIBUTION_DATE = "contribution_date"
+    PUBLICATION = "publication"
+    FORMAL_SPECIFICATION = "formal_specification"
+    HAS_RELEVANT_ORGANIZATION = "has_relevant_organization"
+    USE_CASE_CATEGORY = "use_case_category"
+    RELEVANT_TO_DGPS = "relevant_to_dgps"
+    DATA_TOPICS = "data_topics"
+    STANDARDS_AND_TOOLS_FOR_DGP_USE = "standards_and_tools_for_dgp_use"
+    ENABLES = "enables"
+    INVOLVED_IN_EXPERIMENTAL_DESIGN = "involved_in_experimental_design"
+    INVOLVED_IN_METADATA_MANAGEMENT = "involved_in_metadata_management"
+    INVOLVED_IN_QUALITY_CONTROL = "involved_in_quality_control"
+    XREF = "xref"
+    ALTERNATIVE_STANDARDS_AND_TOOLS = "alternative_standards_and_tools"
+    ROR_ID = "ror_id"
+    WIKIDATA_ID = "wikidata_id"
+
+
+# Possible columns in the standards data tables
+COLUMN_TEMPLATES = {
+    ColumnName.ID: Column(name=ColumnName.ID.value, columnType="STRING", maximumSize=100),
+    ColumnName.CATEGORY: Column(name=ColumnName.CATEGORY.value, columnType="STRING", maximumSize=100),
+    ColumnName.NAME: Column(name=ColumnName.NAME.value, columnType="MEDIUMTEXT"),
+    ColumnName.DESCRIPTION: Column(name=ColumnName.DESCRIPTION.value, columnType="MEDIUMTEXT"),
+    ColumnName.CONTRIBUTOR_NAME: Column(name=ColumnName.CONTRIBUTOR_NAME.value, columnType="STRING", maximumSize=100),
+    ColumnName.CONTRIBUTOR_GITHUB_NAME: Column(name=ColumnName.CONTRIBUTOR_GITHUB_NAME.value, columnType="STRING",
+                                               maximumSize=40),
+    ColumnName.CONTRIBUTOR_ORCID: Column(name=ColumnName.CONTRIBUTOR_ORCID.value, columnType="STRING", maximumSize=50),
+    ColumnName.COLLECTION: Column(name='collection', columnType="STRING", maximumSize=100),
+    ColumnName.PURPOSE_DETAIL: Column(name='purpose_detail', columnType="MEDIUMTEXT"),
+    ColumnName.CONCERNS_DATA_TOPIC: Column(name='concerns_data_topic', columnType="STRING", maximumSize=255),
+    ColumnName.SUBCLASS_OF: Column(name=ColumnName.SUBCLASS_OF.value, columnType="STRING", maximumSize=100),
+    ColumnName.URL: Column(name=ColumnName.URL.value, columnType="MEDIUMTEXT"),
+    ColumnName.IS_OPEN: Column(name=ColumnName.IS_OPEN.value, columnType="BOOLEAN"),
+    ColumnName.REQUIRES_REGISTRATION: Column(name=ColumnName.REQUIRES_REGISTRATION.value, columnType="BOOLEAN"),
+    ColumnName.EDAM_ID: Column(name=ColumnName.EDAM_ID.value, columnType="STRING", maximumSize=25),
+    ColumnName.MESH_ID: Column(name=ColumnName.MESH_ID.value, columnType="STRING", maximumSize=25),
+    ColumnName.NCIT_ID: Column(name=ColumnName.NCIT_ID.value, columnType="STRING", maximumSize=25),
+    ColumnName.RELATED_TO: Column(name=ColumnName.RELATED_TO.value, columnType="STRING", maximumSize=255),
+    ColumnName.METADATA_STORAGE: Column(name=ColumnName.METADATA_STORAGE.value, columnType="STRING", maximumSize=255),
+    ColumnName.FILE_EXTENSIONS: Column(name=ColumnName.FILE_EXTENSIONS.value, columnType="STRING", maximumSize=255),
+    ColumnName.LIMITATIONS: Column(name=ColumnName.LIMITATIONS.value, columnType="MEDIUMTEXT"),
+    ColumnName.CONTRIBUTION_DATE: Column(name=ColumnName.CONTRIBUTION_DATE.value, columnType="STRING", maximumSize=50),
+    ColumnName.PUBLICATION: Column(name=ColumnName.PUBLICATION.value, columnType="STRING", maximumSize=100),
+    ColumnName.FORMAL_SPECIFICATION: Column(name=ColumnName.FORMAL_SPECIFICATION.value, columnType="MEDIUMTEXT"),
+    ColumnName.HAS_RELEVANT_ORGANIZATION: Column(name=ColumnName.HAS_RELEVANT_ORGANIZATION.value, columnType="STRING",
+                                                 maximumSize=100),
+    ColumnName.USE_CASE_CATEGORY: Column(name=ColumnName.USE_CASE_CATEGORY.value, columnType="STRING", maximumSize=100),
+    ColumnName.RELEVANT_TO_DGPS: Column(name=ColumnName.RELEVANT_TO_DGPS.value, columnType="STRING", maximumSize=255),
+    ColumnName.DATA_TOPICS: Column(name=ColumnName.DATA_TOPICS.value, columnType="STRING", maximumSize=255),
+    ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE: Column(name=ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE.value,
+                                                       columnType="STRING", maximumSize=255),
+    ColumnName.ENABLES: Column(name=ColumnName.ENABLES.value, columnType="STRING", maximumSize=255),
+    ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN: Column(name=ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN.value,
+                                                       columnType="BOOLEAN"),
+    ColumnName.INVOLVED_IN_METADATA_MANAGEMENT: Column(name=ColumnName.INVOLVED_IN_METADATA_MANAGEMENT.value,
+                                                       columnType="BOOLEAN"),
+    ColumnName.INVOLVED_IN_QUALITY_CONTROL: Column(name=ColumnName.INVOLVED_IN_QUALITY_CONTROL.value,
+                                                   columnType="BOOLEAN"),
+    ColumnName.XREF: Column(name=ColumnName.XREF.value, columnType="STRING", maximumSize=255),
+    ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS: Column(name=ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS.value,
+                                                       columnType="STRING", maximumSize=255),
+    ColumnName.ROR_ID: Column(name=ColumnName.ROR_ID.value, columnType="STRING", maximumSize=35),
+    ColumnName.WIKIDATA_ID: Column(name=ColumnName.WIKIDATA_ID.value, columnType="STRING", maximumSize=25),
+}
+
+
+class TableSchema(Enum):
+    """An enum for the data tables, containing their ids in the synapse project and their schemas"""
+    DataStandardOrTool = {
+        "id": "syn63096833",
+        "columns": [
+            ColumnName.ID, ColumnName.CATEGORY, ColumnName.NAME, ColumnName.DESCRIPTION, ColumnName.CONTRIBUTOR_NAME,
+            ColumnName.CONTRIBUTOR_GITHUB_NAME, ColumnName.CONTRIBUTOR_ORCID, ColumnName.COLLECTION,
+            ColumnName.CONCERNS_DATA_TOPIC, ColumnName.PURPOSE_DETAIL, ColumnName.IS_OPEN,
+            ColumnName.REQUIRES_REGISTRATION, ColumnName.URL, ColumnName.FORMAL_SPECIFICATION,
+            ColumnName.HAS_RELEVANT_ORGANIZATION, ColumnName.PUBLICATION, ColumnName.SUBCLASS_OF,
+            ColumnName.CONTRIBUTION_DATE
+        ]
+    }
+    DataSubstrate = {
+        "id": "syn63096834",
+        "columns": [
+            ColumnName.ID, ColumnName.CATEGORY, ColumnName.NAME, ColumnName.DESCRIPTION, ColumnName.SUBCLASS_OF,
+            ColumnName.CONTRIBUTOR_NAME, ColumnName.CONTRIBUTOR_GITHUB_NAME, ColumnName.CONTRIBUTOR_ORCID,
+            ColumnName.EDAM_ID, ColumnName.NCIT_ID, ColumnName.RELATED_TO, ColumnName.METADATA_STORAGE,
+            ColumnName.FILE_EXTENSIONS, ColumnName.LIMITATIONS, ColumnName.MESH_ID, ColumnName.CONTRIBUTION_DATE
+        ]
+    }
+    DataTopic = {
+        "id": "syn63096835",
+        "columns": [
+            ColumnName.ID, ColumnName.CATEGORY, ColumnName.NAME, ColumnName.DESCRIPTION, ColumnName.SUBCLASS_OF,
+            ColumnName.CONTRIBUTOR_NAME, ColumnName.CONTRIBUTOR_GITHUB_NAME, ColumnName.CONTRIBUTOR_ORCID,
+            ColumnName.EDAM_ID, ColumnName.MESH_ID, ColumnName.NCIT_ID, ColumnName.RELATED_TO
+        ]
+    }
+    Organization = {
+        "id": "syn63096836",
+        "columns": [
+            ColumnName.ID, ColumnName.CATEGORY, ColumnName.NAME, ColumnName.DESCRIPTION, ColumnName.CONTRIBUTOR_NAME,
+            ColumnName.CONTRIBUTOR_GITHUB_NAME, ColumnName.CONTRIBUTOR_ORCID, ColumnName.ROR_ID,
+            ColumnName.WIKIDATA_ID, ColumnName.URL, ColumnName.SUBCLASS_OF
+        ]
+    }
+    UseCase = {
+        "id": "syn63096837",
+        "columns": [
+            ColumnName.ID, ColumnName.CATEGORY, ColumnName.NAME, ColumnName.DESCRIPTION, ColumnName.CONTRIBUTOR_NAME,
+            ColumnName.CONTRIBUTOR_GITHUB_NAME, ColumnName.CONTRIBUTOR_ORCID, ColumnName.USE_CASE_CATEGORY,
+            ColumnName.RELEVANT_TO_DGPS, ColumnName.DATA_TOPICS, ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE,
+            ColumnName.ENABLES, ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN, ColumnName.INVOLVED_IN_METADATA_MANAGEMENT,
+            ColumnName.INVOLVED_IN_QUALITY_CONTROL, ColumnName.XREF, ColumnName.LIMITATIONS,
+            ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS
+        ]
+    }
+
+
+def main():
+    auth_token = os.getenv("SYNAPSE_AUTH_TOKEN")
+    if not auth_token:
+        raise ValueError("SYNAPSE_AUTH_TOKEN environment variable is not set")
+    syn = Synapse()
+    syn.login(
+        authToken=auth_token)
+
+    project = syn.get("syn63096806")
+
+    for table_schema in TableSchema:
+        table_id = table_schema.value["id"]
+
+        # take snapshot of tables before updating them
+        syn.create_snapshot_version(table_id)
+
+        column_keys = table_schema.value["columns"]
+        columns = [COLUMN_TEMPLATES[key] for key in column_keys]
+
+        schema = Schema(name=table_schema.name, columns=columns, parent=project)
+        table = Table(schema, values=[])
+        syn.store(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-scripts.txt
+++ b/scripts/requirements-scripts.txt
@@ -1,0 +1,1 @@
+synapseclient


### PR DESCRIPTION
Here's the code for updating existing synapse tables when a push to `project/data` files is made to main. 
This script will only work as long as the expected columns remain the same. I ran into too many bugs when trying to feed the synapse client a tsv to update tables with directly, which is why this script gets the rows from a tsv to add them as values.

We get only the files changed and pass them to the script. The script takes the changed files, takes snapshots of the associated tables, deletes all of their data, and repopulates using the new tsv. This may seem inefficient, but it's the best workaround for now, until synapseclient supports upserting to tables. 

I also have the code for creating schemas on my fork here: https://github.com/katiestahl/b2ai-standards-registry/blob/main/.github/scripts/create_synapse_tables.py 
I was unsure if I should add that to this PR or not, since it's pretty messy and could use some love in that regard (but it gets the job done :-) ), but it illustrates the schemas as they currently are, and if we ever need to add or update columns, we will need to update and run that script. 


Also note: before merging this script, we will need to create a service account in synapse for updating the tables and add its auth token as a secret `SYNAPSE_AUTH_TOKEN` to our github actions. We should have a dedicated account in Synapse that's not tied to any of our personal accounts, so it's clear when the tables have been updated from the github action. 