### PR TITLE
fix: only detect tsv file changes for updating synapse tables

### DIFF
--- a/.github/workflows/project_data_change.yml
+++ b/.github/workflows/project_data_change.yml
@@ -33,7 +33,7 @@ jobs:
         id: changes
         run: |
           CHANGED_FILES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.files[].filename' | grep 'project/data/')
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.files[].filename' | grep 'project/data/.*\.tsv$')
           CHANGED_FILES=$(echo "$CHANGED_FILES" | tr '\n' ' ')
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
           echo "Files changed: $CHANGED_FILES"


### PR DESCRIPTION
looks like the old action failed because of a bug in the workflow - it was getting all changed files and not just the tsv's needed for the script. 