### PR TITLE
fix: use STRING_LIST for synapse table schemas

### DIFF
--- a/.github/scripts/update_synapse_tables.py
+++ b/.github/scripts/update_synapse_tables.py
@@ -1,16 +1,18 @@
 import csv
+import json
 import sys
 from synapseclient import Synapse, Table
 import os
+import pandas as pd
 
 
 # the paths detected as changes from the "Get changed files" job mapped to their corresponding synapse table ids
 PATHS_TO_IDS = {
-    "project/data/DataStandardOrTool.tsv": "syn63096833",
-    "project/data/DataSubstrate.tsv": "syn63096834",
-    "project/data/DataTopic.tsv": "syn63096835",
-    "project/data/Organization.tsv": "syn63096836",
-    "project/data/UseCase.tsv": "syn63096837",
+    "project/data/DataStandardOrTool.json": "syn63096833",
+    "project/data/DataSubstrate.json": "syn63096834",
+    "project/data/DataTopic.json": "syn63096835",
+    "project/data/Organization.json": "syn63096836",
+    "project/data/UseCase.json": "syn63096837",
 }
 
 
@@ -25,31 +27,23 @@ def delete_table_rows(syn: Synapse, table_id: str) -> None:
     print("Finished deleting rows")
 
 
-def get_rows_from_tsv(file_path: str):
-    """Read a TSV file and return a list of lists, where each inner list represents a row.
-    NOTE: The first row of the file is expected to be the headers, which is skipped
-    :param file_path: path to tsv file
-    :return: list of lists representing rows of the tsv file"""
-    rows = []
-    with open(file_path, mode="r", newline="", encoding="utf-8") as tsv_file:
-        reader = csv.reader(tsv_file, delimiter="\t")
-        # Skip the header row
-        next(reader)
-        for row in reader:
-            rows.append(row)
-    return rows
-
-
 def populate_table(syn: Synapse, update_file: str, table_id: str) -> None:
     """Populate the table with updated data
     :param syn: synapse client
-    :param update_file: path for tsv file containing data to populate the table
+    :param update_file: path for json file containing data to populate the table
     :param table_id: synapse id for table to populate
     """
-    rows_to_add = get_rows_from_tsv(update_file)
-    print(f"Populating table for file: {update_file}")
-    table = syn.store(Table(table_id, rows_to_add))
-    print("Finished populating table")
+    with open(update_file, "r") as file:
+        data = json.load(file)
+    # each json file begins with a key that maps to the list of records, so we're accessing that list here
+    data = next(iter(data.values()), [])
+    if isinstance(data, list):
+        df = pd.DataFrame(data=data)
+        print(f"Populating table for file: {update_file}")
+        table = syn.store(Table(table_id, df))
+        print("Finished populating table")
+    else:
+        print("Could not get list of data from json file")
 
 
 def main():

--- a/.github/scripts/update_synapse_tables.py
+++ b/.github/scripts/update_synapse_tables.py
@@ -19,7 +19,7 @@ def delete_table_rows(syn: Synapse, table_id: str) -> None:
     :param syn: synapse client
     :param table_id: table id to delete rows for
     """
-    print("Deleting rows from table {table_id}")
+    print(f"Deleting rows from table {table_id}")
     results = syn.tableQuery(f"select * from {table_id}")
     syn.delete(results)
     print("Finished deleting rows")

--- a/.github/workflows/project_data_change.yml
+++ b/.github/workflows/project_data_change.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'project/data/*.tsv'
+      - 'project/data/*.json'
 
 jobs:
   update_synapse_tables:
@@ -33,7 +33,7 @@ jobs:
         id: changes
         run: |
           CHANGED_FILES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.files[].filename' | grep 'project/data/.*\.tsv$')
+          https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }} | jq -r '.files[].filename' | grep 'project/data/.*\.json$')
           CHANGED_FILES=$(echo "$CHANGED_FILES" | tr '\n' ' ')
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
           echo "Files changed: $CHANGED_FILES"
@@ -43,7 +43,7 @@ jobs:
           if [ -n "${{ env.CHANGED_FILES }}" ]; then
             python3 .github/scripts/update_synapse_tables.py ${{ env.CHANGED_FILES }}
           else
-            echo "No relevant TSV files changed."
+            echo "No relevant json files changed."
           fi
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}

--- a/scripts/modify_synapse_schema.py
+++ b/scripts/modify_synapse_schema.py
@@ -29,13 +29,14 @@ class ColumnName(Enum):
     METADATA_STORAGE = "metadata_storage"
     FILE_EXTENSIONS = "file_extensions"
     LIMITATIONS = "limitations"
+    KNOWN_LIMITATIONS = "known_limitations"
     CONTRIBUTION_DATE = "contribution_date"
     PUBLICATION = "publication"
     FORMAL_SPECIFICATION = "formal_specification"
     HAS_RELEVANT_ORGANIZATION = "has_relevant_organization"
     HAS_TRAINING_RESOURCE = "has_training_resource"
     USE_CASE_CATEGORY = "use_case_category"
-    RELEVANT_TO_DGPS = "relevant_to_dgps"
+    RELEVANCE_TO_DGPS = "relevance_to_dgps"
     DATA_TOPICS = "data_topics"
     STANDARDS_AND_TOOLS_FOR_DGP_USE = "standards_and_tools_for_dgp_use"
     ENABLES = "enables"
@@ -72,14 +73,16 @@ COLUMN_TEMPLATES = {
         name=ColumnName.CONTRIBUTOR_ORCID.value, columnType="STRING", maximumSize=50
     ),
     ColumnName.COLLECTION: Column(
-        name="collection", columnType="STRING_LIST"
+        name="collection", columnType="STRING_LIST", maximumListLength=25
     ),
     ColumnName.PURPOSE_DETAIL: Column(name="purpose_detail", columnType="MEDIUMTEXT"),
     ColumnName.CONCERNS_DATA_TOPIC: Column(
-        name="concerns_data_topic", columnType="STRING_LIST"
+        name="concerns_data_topic", columnType="STRING_LIST", maximumListLength=25
     ),
     ColumnName.SUBCLASS_OF: Column(
-        name=ColumnName.SUBCLASS_OF.value, columnType="STRING_LIST"
+        name=ColumnName.SUBCLASS_OF.value,
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.URL: Column(name=ColumnName.URL.value, columnType="MEDIUMTEXT"),
     ColumnName.IS_OPEN: Column(name=ColumnName.IS_OPEN.value, columnType="BOOLEAN"),
@@ -96,16 +99,23 @@ COLUMN_TEMPLATES = {
         name=ColumnName.NCIT_ID.value, columnType="STRING", maximumSize=25
     ),
     ColumnName.RELATED_TO: Column(
-        name=ColumnName.RELATED_TO.value, columnType="MEDIUMTEXT"
+        name=ColumnName.RELATED_TO.value, columnType="STRING_LIST", maximumListLength=25
     ),
     ColumnName.METADATA_STORAGE: Column(
-        name=ColumnName.METADATA_STORAGE.value, columnType="STRING_LIST"
+        name=ColumnName.METADATA_STORAGE.value,
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.FILE_EXTENSIONS: Column(
-        name=ColumnName.FILE_EXTENSIONS.value, columnType="STRING_LIST"
+        name=ColumnName.FILE_EXTENSIONS.value,
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.LIMITATIONS: Column(
         name=ColumnName.LIMITATIONS.value, columnType="MEDIUMTEXT"
+    ),
+    ColumnName.KNOWN_LIMITATIONS: Column(
+        name=ColumnName.KNOWN_LIMITATIONS.value, columnType="MEDIUMTEXT"
     ),
     ColumnName.CONTRIBUTION_DATE: Column(
         name=ColumnName.CONTRIBUTION_DATE.value, columnType="STRING", maximumSize=50
@@ -118,27 +128,34 @@ COLUMN_TEMPLATES = {
     ),
     ColumnName.HAS_RELEVANT_ORGANIZATION: Column(
         name=ColumnName.HAS_RELEVANT_ORGANIZATION.value,
-        columnType="STRING_LIST"
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.HAS_TRAINING_RESOURCE: Column(
         name=ColumnName.HAS_TRAINING_RESOURCE.value,
         columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.USE_CASE_CATEGORY: Column(
         name=ColumnName.USE_CASE_CATEGORY.value, columnType="STRING", maximumSize=100
     ),
-    ColumnName.RELEVANT_TO_DGPS: Column(
-        name=ColumnName.RELEVANT_TO_DGPS.value, columnType="STRING_LIST"
+    ColumnName.RELEVANCE_TO_DGPS: Column(
+        name=ColumnName.RELEVANCE_TO_DGPS.value,
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.DATA_TOPICS: Column(
-        name=ColumnName.DATA_TOPICS.value, columnType="STRING_LIST"
+        name=ColumnName.DATA_TOPICS.value,
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE: Column(
         name=ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE.value,
-        columnType="STRING_LIST"
+        columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.ENABLES: Column(
-        name=ColumnName.ENABLES.value, columnType="STRING_LIST"
+        name=ColumnName.ENABLES.value, columnType="STRING_LIST", maximumListLength=25
     ),
     ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN: Column(
         name=ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN.value, columnType="BOOLEAN"
@@ -150,11 +167,12 @@ COLUMN_TEMPLATES = {
         name=ColumnName.INVOLVED_IN_QUALITY_CONTROL.value, columnType="BOOLEAN"
     ),
     ColumnName.XREF: Column(
-        name=ColumnName.XREF.value, columnType="STRING_LIST"
+        name=ColumnName.XREF.value, columnType="STRING_LIST", maximumListLength=25
     ),
     ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS: Column(
         name=ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS.value,
         columnType="STRING_LIST",
+        maximumListLength=25,
     ),
     ColumnName.ROR_ID: Column(
         name=ColumnName.ROR_ID.value, columnType="STRING", maximumSize=35
@@ -257,7 +275,7 @@ class TableSchema(Enum):
             ColumnName.CONTRIBUTOR_GITHUB_NAME,
             ColumnName.CONTRIBUTOR_ORCID,
             ColumnName.USE_CASE_CATEGORY,
-            ColumnName.RELEVANT_TO_DGPS,
+            ColumnName.RELEVANCE_TO_DGPS,
             ColumnName.DATA_TOPICS,
             ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE,
             ColumnName.ENABLES,
@@ -265,7 +283,7 @@ class TableSchema(Enum):
             ColumnName.INVOLVED_IN_METADATA_MANAGEMENT,
             ColumnName.INVOLVED_IN_QUALITY_CONTROL,
             ColumnName.XREF,
-            ColumnName.LIMITATIONS,
+            ColumnName.KNOWN_LIMITATIONS,
             ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS,
         ],
     }

--- a/scripts/modify_synapse_schema.py
+++ b/scripts/modify_synapse_schema.py
@@ -72,14 +72,14 @@ COLUMN_TEMPLATES = {
         name=ColumnName.CONTRIBUTOR_ORCID.value, columnType="STRING", maximumSize=50
     ),
     ColumnName.COLLECTION: Column(
-        name="collection", columnType="STRING", maximumSize=100
+        name="collection", columnType="STRING_LIST"
     ),
     ColumnName.PURPOSE_DETAIL: Column(name="purpose_detail", columnType="MEDIUMTEXT"),
     ColumnName.CONCERNS_DATA_TOPIC: Column(
-        name="concerns_data_topic", columnType="STRING", maximumSize=255
+        name="concerns_data_topic", columnType="STRING_LIST"
     ),
     ColumnName.SUBCLASS_OF: Column(
-        name=ColumnName.SUBCLASS_OF.value, columnType="STRING", maximumSize=100
+        name=ColumnName.SUBCLASS_OF.value, columnType="STRING_LIST"
     ),
     ColumnName.URL: Column(name=ColumnName.URL.value, columnType="MEDIUMTEXT"),
     ColumnName.IS_OPEN: Column(name=ColumnName.IS_OPEN.value, columnType="BOOLEAN"),
@@ -96,13 +96,13 @@ COLUMN_TEMPLATES = {
         name=ColumnName.NCIT_ID.value, columnType="STRING", maximumSize=25
     ),
     ColumnName.RELATED_TO: Column(
-        name=ColumnName.RELATED_TO.value, columnType="STRING", maximumSize=255
+        name=ColumnName.RELATED_TO.value, columnType="MEDIUMTEXT"
     ),
     ColumnName.METADATA_STORAGE: Column(
-        name=ColumnName.METADATA_STORAGE.value, columnType="STRING", maximumSize=255
+        name=ColumnName.METADATA_STORAGE.value, columnType="STRING_LIST"
     ),
     ColumnName.FILE_EXTENSIONS: Column(
-        name=ColumnName.FILE_EXTENSIONS.value, columnType="STRING", maximumSize=255
+        name=ColumnName.FILE_EXTENSIONS.value, columnType="STRING_LIST"
     ),
     ColumnName.LIMITATIONS: Column(
         name=ColumnName.LIMITATIONS.value, columnType="MEDIUMTEXT"
@@ -118,30 +118,27 @@ COLUMN_TEMPLATES = {
     ),
     ColumnName.HAS_RELEVANT_ORGANIZATION: Column(
         name=ColumnName.HAS_RELEVANT_ORGANIZATION.value,
-        columnType="STRING",
-        maximumSize=100,
+        columnType="STRING_LIST"
     ),
     ColumnName.HAS_TRAINING_RESOURCE: Column(
         name=ColumnName.HAS_TRAINING_RESOURCE.value,
-        columnType="STRING",
-        maximumSize=255,
+        columnType="STRING_LIST",
     ),
     ColumnName.USE_CASE_CATEGORY: Column(
         name=ColumnName.USE_CASE_CATEGORY.value, columnType="STRING", maximumSize=100
     ),
     ColumnName.RELEVANT_TO_DGPS: Column(
-        name=ColumnName.RELEVANT_TO_DGPS.value, columnType="STRING", maximumSize=255
+        name=ColumnName.RELEVANT_TO_DGPS.value, columnType="STRING_LIST"
     ),
     ColumnName.DATA_TOPICS: Column(
-        name=ColumnName.DATA_TOPICS.value, columnType="STRING", maximumSize=255
+        name=ColumnName.DATA_TOPICS.value, columnType="STRING_LIST"
     ),
     ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE: Column(
         name=ColumnName.STANDARDS_AND_TOOLS_FOR_DGP_USE.value,
-        columnType="STRING",
-        maximumSize=255,
+        columnType="STRING_LIST"
     ),
     ColumnName.ENABLES: Column(
-        name=ColumnName.ENABLES.value, columnType="STRING", maximumSize=255
+        name=ColumnName.ENABLES.value, columnType="STRING_LIST"
     ),
     ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN: Column(
         name=ColumnName.INVOLVED_IN_EXPERIMENTAL_DESIGN.value, columnType="BOOLEAN"
@@ -153,12 +150,11 @@ COLUMN_TEMPLATES = {
         name=ColumnName.INVOLVED_IN_QUALITY_CONTROL.value, columnType="BOOLEAN"
     ),
     ColumnName.XREF: Column(
-        name=ColumnName.XREF.value, columnType="STRING", maximumSize=255
+        name=ColumnName.XREF.value, columnType="STRING_LIST"
     ),
     ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS: Column(
         name=ColumnName.ALTERNATIVE_STANDARDS_AND_TOOLS.value,
-        columnType="STRING",
-        maximumSize=255,
+        columnType="STRING_LIST",
     ),
     ColumnName.ROR_ID: Column(
         name=ColumnName.ROR_ID.value, columnType="STRING", maximumSize=35
@@ -204,12 +200,12 @@ class TableSchema(Enum):
             ColumnName.NAME,
             ColumnName.DESCRIPTION,
             ColumnName.SUBCLASS_OF,
+            ColumnName.RELATED_TO,
             ColumnName.CONTRIBUTOR_NAME,
             ColumnName.CONTRIBUTOR_GITHUB_NAME,
             ColumnName.CONTRIBUTOR_ORCID,
             ColumnName.EDAM_ID,
             ColumnName.NCIT_ID,
-            ColumnName.RELATED_TO,
             ColumnName.METADATA_STORAGE,
             ColumnName.FILE_EXTENSIONS,
             ColumnName.LIMITATIONS,


### PR DESCRIPTION
I didn't realize there was a STRING_LIST data type for columns when I first implemented this work. 

The work in this PR is to convert to using STRING_LIST columns in the schema instead of STRING and also includes improvements to the automatic update script, where instead of using the tsv, we use json and convert to a pandas dataframe for more reliable updating and less manual work for the script. 