### PR TITLE
docs: update readme requirements to include bash 4.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Our Standards Registry goals are threefold:
 
 1. Ensure integration of the standards development lifecycle within the context of B2AI activities.
 2. Narrow the large space of standards to what is relevant.
-3. Provide computational access and utilities for schemas and standards, rather than links to often outdated PDFs. 
+3. Provide computational access and utilities for schemas and standards, rather than links to often outdated PDFs.
 
 ## Repository Structure
 
@@ -59,6 +59,27 @@ To submit a new data standard or other entry to the Registry (including data top
 
 Data objects are defined according to the [standards-schemas](https://github.com/bridge2ai/standards-schemas).
 
+### Requirements
+
+This project requires **GNU Make** and **Bash**. Ensure you have a recent version of Bash installed:
+
+* **Linux**: Bash is usually pre-installed
+* **macOS**: The system default Bash (`/bin/bash`) is an older version (3.2). To use newer features, install a recent version via Homebrew:
+
+```sh
+brew install bash
+```
+
+* **Windows**: Use WSL (Windows Subsystem for Linux) or Git Bash to run Make commands.
+
+**Minimum Bash Version:** This project requires **Bash 4.0 or later** due to its use of associative arrays. Check your version with:
+
+```sh
+bash --version
+```
+
+If you encounter issues, ensure your system is using the correct version of Bash.
+
 ### Project Generation
 
 Use the `make` command to generate project artifacts:
@@ -77,11 +98,11 @@ Please see the [src/data](src/data) directory for data in YAML format or the [pr
 
 <details>
 <summary>References</summary>
-  
+
 1. Gebru T, Morgenstern J, Vecchione B, Vaughan JW, Wallach H, Daumé H III, Crawford K. Datasheets for Datasets. arXiv [cs.DB]. 2018. arxiv.org/abs/1803.09010
 2. Mitchell M, Wu S, Zaldivar A, Barnes P, Vasserman L, Hutchinson B, Spitzer E, Raji ID, Gebru T. Model cards for model reporting. Proceedings of the Conference on Fairness, Accountability, and Transparency. New York, NY, USA: ACM; 2019. dl.acm.org/doi/10.1145/3287560.3287596
 3. Yilmaz P, Kottmann R, Field D, Knight R, Cole JR, Amaral-Zettler L, Gilbert JA, Karsch-Mizrachi I, Johnston A, Cochrane G, Vaughan R, Hunter C, Park J, Morrison N, Rocca-Serra P, Sterk P, Arumugam M, Bailey M, Baumgartner L, Birren BW, Blaser MJ, Bonazzi V, Booth T, Bork P, Bushman FD, Buttigieg PL, Chain PSG, Charlson E, Costello EK, Huot-Creasy H, Dawyndt P, DeSantis T, Fierer N, Fuhrman JA, Gallery RE, Gevers D, Gibbs RA, San Gil I, Gonzalez A, Gordon JI, Guralnick R, Hankeln W, Highlander S, Hugenholtz P, Jansson J, Kau AL, Kelley ST, Kennedy J, Knights D, Koren O, Kuczynski J, Kyrpides N, Larsen R, Lauber CL, Legg T, Ley RE, Lozupone CA, Ludwig W, Lyons D, Maguire E, Methé BA, Meyer F, Muegge B, Nakielny S, Nelson KE, Nemergut D, Neufeld JD, Newbold LK, Oliver AE, Pace NR, Palanisamy G, Peplies J, Petrosino J, Proctor L, Pruesse E, Quast C, Raes J, Ratnasingham S, Ravel J, Relman DA, Assunta-Sansone S, Schloss PD, Schriml L, Sinha R, Smith MI, Sodergren E, Spo A, Stombaugh J, Tiedje JM, Ward DV, Weinstock GM, Wendel D, White O, Whiteley A, Wilke A, Wortman JR, Yatsunenko T, Glöckner FO. Minimum information about a marker gene sequence (MIMARKS) and minimum information about any (x) sequence (MIxS) specifications. Nat Biotechnol. 2011 May;29(5):415–420. dx.doi.org/10.1038/nbt.1823 PMCID: PMC3367316
 4. Osterman TJ, Terry M, Miller RS. Improving Cancer Data Interoperability: The Promise of the Minimal Common Oncology Data Elements (mCODE) Initiative. JCO Clin Cancer Inform. 2020 Oct;4:993–1001. dx.doi.org/10.1200/CCI.20.00059 PMCID: PMC7713551
 5. Ritter DI, Roychowdhury S, Roy A, Rao S, Landrum MJ, Sonkin D, Shekar M, Davis CF, Hart RK, Micheel C, Weaver M, Van Allen EM, Parsons DW, McLeod HL, Watson MS, Plon SE, Kulkarni S, Madhavan S, ClinGen Somatic Cancer Working Group. Somatic cancer variant curation and harmonization through consensus minimum variant level data. Genome Med. 2016 Nov 4;8(1):117. dx.doi.org/10.1186/s13073-016-0367-z PMCID: PMC5095986
-  
+
 </details>

--- a/project.Makefile
+++ b/project.Makefile
@@ -1,5 +1,5 @@
 ## Add your own custom Makefile targets here
-SHELL=/bin/bash
+SHELL := /usr/bin/env bash
 
 SCHEMA_FILES := standards_datastandardortool_schema.yaml \
 standards_datasubstrate_schema.yaml \
@@ -63,7 +63,7 @@ src/schema:
 # Mkdocs reads the tsv versions.
 site: all-data doc-data-markdown
 	mkdocs build ;
-	
+
 # Use schemas to validate the data.
 # could use IN ZIP_LISTS if this was CMake, but it isn't
 # so we do a somewhat messy array instead


### PR DESCRIPTION
Anyone developing on a mac will need to upgrade their bash version since macs can't have a newer version of bash due to licensing issues. I added a requirements section in the README to explain this, and I also edited the first line of the Makefile to use an overridden bash version for mac users. This line should still work on all other OS's as well (but I can't test that out. If anyone uses Windows and could verify I didn't break anything, that would be awesome)