### PR TITLE
ci: update test GH action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
 
@@ -18,10 +18,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -29,25 +29,19 @@ jobs:
       #          install & configure poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        uses: snok/install-poetry@v1
 
       #----------------------------------------------
-      # install dependencies if cache does not exist 
+      # install dependencies if cache does not exist
       #----------------------------------------------
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
       #----------------------------------------------
-      #    Skip installing the root package
-      #----------------------------------------------      
-      #- name: Install library
-      #  run: poetry install --no-interaction
-
+      #    Test the schema
       #----------------------------------------------
-      #    Run tests
-      #----------------------------------------------
-      #- name: Run validator tests
-      #  run: make test
+      - name: Test the schema
+        run: make test-schema
 
       #----------------------------------------------
       #    Validate data


### PR DESCRIPTION
close #163

* Add 3.11 - 3.12 to python version matrix
* Update actions versions
* Remove commented out code
* Uncomment running the test validator step. There are no unit tests, so it doesn't make sense to run `make test-python`
* We'll need #174 to prevent merging if checks fail
