### PR TITLE
fix: add missing column for DataStandardOrTool 

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,14 +41,14 @@ To run these scripts, you’ll need to install the required dependencies. This c
 
 Each script is intended to be run individually. Here’s how to use them:
 
-### Example Script: table_schema_setup.py
+### Example Script: modify_synapse_schema.py
 
 **Description:** Sets up and manages table schemas in Synapse, defining the column structure for each table.
 
 **Run:**
 
 ```bash
-python scripts/table_schema_setup.py
+python scripts/modify_synapse_schema.py
 ```
 
 #### Requirements

--- a/scripts/modify_synapse_schema.py
+++ b/scripts/modify_synapse_schema.py
@@ -182,7 +182,7 @@ COLUMN_TEMPLATES = {
         name=ColumnName.WIKIDATA_ID.value, columnType="STRING", maximumSize=25
     ),
     ColumnName.RESPONSIBLE_ORGANIZATION: Column(
-        name=ColumnName.RESPONSIBLE_ORGANIZATION, columnType="STRING_LIST", maximumListLength=25
+        name=ColumnName.RESPONSIBLE_ORGANIZATION.value, columnType="STRING_LIST", maximumListLength=25
     )
 }
 

--- a/scripts/modify_synapse_schema.py
+++ b/scripts/modify_synapse_schema.py
@@ -47,6 +47,7 @@ class ColumnName(Enum):
     ALTERNATIVE_STANDARDS_AND_TOOLS = "alternative_standards_and_tools"
     ROR_ID = "ror_id"
     WIKIDATA_ID = "wikidata_id"
+    RESPONSIBLE_ORGANIZATION = "responsible_organization"
 
 
 # Possible columns in the standards data tables
@@ -180,6 +181,9 @@ COLUMN_TEMPLATES = {
     ColumnName.WIKIDATA_ID: Column(
         name=ColumnName.WIKIDATA_ID.value, columnType="STRING", maximumSize=25
     ),
+    ColumnName.RESPONSIBLE_ORGANIZATION: Column(
+        name=ColumnName.RESPONSIBLE_ORGANIZATION, columnType="STRING_LIST", maximumListLength=25
+    )
 }
 
 
@@ -209,6 +213,7 @@ class TableSchema(Enum):
             ColumnName.SUBCLASS_OF,
             ColumnName.CONTRIBUTION_DATE,
             ColumnName.RELATED_TO,
+            ColumnName.RESPONSIBLE_ORGANIZATION,
         ],
     }
     DataSubstrate = {


### PR DESCRIPTION
responsible_organization was not added to the script. I ran the script to update the table and will rerun the failing action here 
https://github.com/bridge2ai/b2ai-standards-registry/actions/runs/14065291972/job/39386097706#step:7:41