### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@caufieldjh @jennifer-bowser @katiestahl @korikuzma @Krt-11


### PR DESCRIPTION
close #236

I don't love using individual GH handles, but if we want to require > 1 approval from CODEOWNERS we've found that this works best (otherwise, once a CODEOWNER reviews then others are removed as reviewers)