### PR TITLE
docs: update author list in 'pyproject.toml'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,13 @@ name = "b2ai-standards-registry"
 version = "0.1.2"
 description = "Bridge2AI Standards Registry and Use Case Catalog, including validation functions."
 authors = [
-	{name = "caufieldjh", email = "j.harry.caufield@gmail.com>"}
+	{name = "caufieldjh", email = "j.harry.caufield@gmail.com"},
+	{name = "jennifer-bowser", email = "jduffbowser@gmail.com"},
+	{name = "korikuzma", email = "kori.kuzma@nationwidechildrens.org"},
+	{name = "katiestahl", email = "kathryn.stahl@nationwidechildrens.org"},
+	{name = "Krt-11", email = "krutin.shukla@nationwidechildrens.org"},
+	{name = "jaeddy"},
+	{name = "monicacecilia"}
 ]
 license = {text = "MIT"}
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ authors = [
 	{name = "korikuzma", email = "kori.kuzma@nationwidechildrens.org"},
 	{name = "katiestahl", email = "kathryn.stahl@nationwidechildrens.org"},
 	{name = "Krt-11", email = "krutin.shukla@nationwidechildrens.org"},
-	{name = "jaeddy"},
-	{name = "monicacecilia"}
+	{name = "monicacecilia", email = "monica.munoz-torres@cuanschutz.edu"},
+	{name = "jaeddy"}
 ]
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
closes #241 

I stuck with the convention of using GitHub usernames for the `name` field.

The last two authors are people listed on the repo's [Contributors](https://github.com/bridge2ai/b2ai-standards-registry/graphs/contributors) page. Their GitHub profiles don't have emails for them, so I left that field off. 

For NCH contributors, I used your NCH email address. Let me know if you'd like me to use the email associated with your GitHub account, or any other personal email address, instead.