### PR TITLE
fix: add missing `*` to list all files in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@caufieldjh @jennifer-bowser @katiestahl @korikuzma @Krt-11
+* @caufieldjh @jennifer-bowser @katiestahl @korikuzma @Krt-11


### PR DESCRIPTION
🤦 

I was wondering why i kept having to select everyone as reviewers