### PR TITLE
refactor: use `GITHUB_OUTPUT` instead of deprecated `set-output`

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -600,11 +600,10 @@ def main(dry: bool, github: bool, force: bool) -> None:
     branch_name = str(uuid4())[:8]
 
     if github:
-        msg = f"""
-          ::set-output name=PR_BODY::{body}
-          ::set-output name=PR_TITLE::{title}
-        """
-        exit_with_msg(msg=msg, exit_status_code=ExitCode.SUCCESS)
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            click.echo(f"PR_BODY={body}", file=f)
+            click.echo(f"PR_TITLE={title}", file=f)
+        exit_with_msg(exit_status_code=ExitCode.SUCCESS)
     elif dry:
         click.echo("New branch would have been:")
         click.echo(f"title: {title}")


### PR DESCRIPTION
close #239

Duplicate of #258 , I don't know if branches delete after merging (or maybe I merged too fast before it could delete). 