### PR TITLE
feat: add workflow for closing an issue automatically on PR merge

### DIFF
--- a/.github/workflows/close_issue.yaml
+++ b/.github/workflows/close_issue.yaml
@@ -1,0 +1,18 @@
+name: Close issues related to a merged pull request based on main branch.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  closeIssueOnPrMergeTrigger:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Closes issues related to a merged pull request.
+        uses: ldez/gha-mjolnir@v1.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thought this might be a nice QoL improvement - this will automatically close issues that have been merged as long as they're marked like "close #issuenumber"