### PR TITLE
feat: run yaml formatter after new entity has been added to data .yaml files

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -60,8 +60,7 @@ import more_itertools
 import requests
 import yaml
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from scripts.format_yaml import format_yaml_file
+from ...scripts.format_yaml import format_yaml_file
 
 logger = logging.getLogger(__name__)
 
@@ -535,8 +534,7 @@ def _update_yaml(issue_to_resource: Dict[int, dict]) -> None:
         if this_yaml:
             with open(data_path, "w") as yamlfile:
                 yaml.safe_dump(this_yaml, yamlfile, sort_keys=False)
-
-        format_yaml_file(data_path)
+            format_yaml_file(data_path)
 
 
 @click.command()

--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -45,6 +45,7 @@ from enum import Enum, IntEnum
 import itertools as itt
 import logging
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
@@ -58,6 +59,9 @@ import click
 import more_itertools
 import requests
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from scripts.format_yaml import format_yaml_file
 
 logger = logging.getLogger(__name__)
 
@@ -531,6 +535,8 @@ def _update_yaml(issue_to_resource: Dict[int, dict]) -> None:
         if this_yaml:
             with open(data_path, "w") as yamlfile:
                 yaml.safe_dump(this_yaml, yamlfile, sort_keys=False)
+
+        format_yaml_file(data_path)
 
 
 @click.command()


### PR DESCRIPTION
I am calling the `format_yaml_files` function in the process issue file. This will run after a new entity has been added to the mentioned `src/data` file making sure it matches the consistent format.

close #245 