### PR TITLE
feat: only create PR if entity does not already exist

### DIFF
--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -610,7 +610,6 @@ def main(dry: bool, github: bool, force: bool) -> None:
 
     issue_to_resource = filtered
 
-
     if issue_to_resource:
         click.echo(f"Adding {len(issue_to_resource)} issues after filter")
     else:

--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -536,14 +536,11 @@ def _update_yaml(issue_to_resource: Dict[int, dict]) -> None:
 
 def entity_exists_in_file(entity_name: str, file_path: str) -> bool:
     """
-    Checks if an entity with the given name exists in the specific YAML file.
+    Check if an entity exists in a YAML file.
 
-    Args:
-        entity_name (str): The entity name to search for.
-        file_path (str): Full path to the YAML file to check.
-
-    Returns:
-        bool: True if the entity exists, False otherwise.
+    :param entity_name: The entity name to search for
+    :param file_path: Full path to the YAML file to check
+    :return: True if the entity exists, False otherwise
     """
     if not os.path.exists(file_path):
         return False

--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -245,7 +245,6 @@ def open_pull_request(
     ).json()
 
 
-
 def get_b2ai_standards_registry_form_data(
     labels: Iterable[str],
     token: str,

--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -548,6 +548,7 @@ def entity_exists_in_file(entity_name: str, file_path: str) -> bool:
         try:
             content = yaml.safe_load(f)
             if not isinstance(content, dict):
+                click.secho(f" Unexpected content format in {file_path} (not a dict)", fg="yellow")
                 return False
             for collection in content.values():
                 if isinstance(collection, list):
@@ -555,7 +556,7 @@ def entity_exists_in_file(entity_name: str, file_path: str) -> bool:
                         if isinstance(item, dict) and item.get("name") == entity_name:
                             return True
         except yaml.YAMLError as e:
-            print(f"Error reading {file_path}: {e}")
+            click.secho(f"YAML error while reading {file_path}: {e}", fg="red")
     return False
 
 

--- a/.github/scripts/process_issue.py
+++ b/.github/scripts/process_issue.py
@@ -548,7 +548,7 @@ def entity_exists_in_file(entity_name: str, file_path: str) -> bool:
         try:
             content = yaml.safe_load(f)
             if not isinstance(content, dict):
-                click.secho(f" Unexpected content format in {file_path} (not a dict)", fg="yellow")
+                click.secho(f"Unexpected content format in {file_path} (not a dict)", fg="yellow")
                 return False
             for collection in content.values():
                 if isinstance(collection, list):


### PR DESCRIPTION
### Check if an entity requested to be added already exists in `src/data` files. 

- If the entity already exists, the process will **skip** creating a pull request for that entity.
- If the entity does not exist, the workflow will proceed as normal and a pull request will be created.

close #201 