### PR TITLE
Add new docs for Explorer

### DIFF
--- a/docs/categories.md
+++ b/docs/categories.md
@@ -1,0 +1,69 @@
+# Categories in the Bridge2AI Standards Explorer
+
+The Bridge2AI Standards Explorer categorizes data standards and tools into several categories. Each category represents a specific type of standard or tool with its own unique characteristics and purposes.
+
+## Data Standard or Tool Classes
+
+### Data Standard or Tool
+The base class for all standards and tools in the Explorer. In practice, no resource will have this category, but will be assigned one of the categories below.
+
+**Each standard or tool may:**
+* Be associated with data topics
+* Have relevant organizations
+* Have training resources
+* Include details like openness status, registration requirements, URLs, and publications
+
+### Data Standard
+A general purpose data. This represents specifications, schemas, or guidelines for data management. It may not have been developed specifically for biomedical or biological research data, but is relevant to data science more broadly or has been adopted for specific research purposes.
+
+### Biomedical Standard
+A specialized standard with particular applications or relevance to clinical or biomedical research purposes. These standards address the unique needs of biomedical data.
+
+### Registry
+A resource that serves to curate and/or index other resources. Registries provide a centralized location to discover and access other standards or tools.
+
+### Ontology Or Vocabulary
+A set of concepts and categories, potentially defined or accompanied by their hierarchical relationships. These provide standardized terminologies and semantics for consistent data annotation.
+
+### Model Repository
+A resource serving to curate and store computational models. Unlike registries that may only index models, a model repository must provide storage functionality, such that users can retrieve the models for their own use.
+
+### Reference Data Or Dataset
+A standardized, reusable data source. These resources provide benchmark or canonical data that can be used across multiple research projects.
+
+### Software Or Tool
+A piece of software or computational tool. These resources provide implementations of algorithms, analysis methods, or other computational capabilities. They may not have been developed explicitly for biomedical or biological research.
+
+### Reference Implementation
+An implementation of one or more standards or tools, whether as a full specification in a particular language or as an application to a specific use case. These demonstrate how to properly implement standards or use tools. These implementations may not have their own names and in these cases are referred to with a name based on their corresponding publication (e.g., [B2AI_STANDARD:687](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:687) is Gupta2021).
+
+### Training Program
+A program for developing skills and experience related to standards or tools. These resources help users learn how to effectively apply standards or use tools.
+
+## Classification Tags
+
+Standards and tools can be tagged with specific collection tags to further categorize them. Some of the available tags include:
+
+- **audiovisual**: Audiovisual standards
+- **fileformat**: File format standards
+- **toolkit**: Bioinformatics toolkits
+- **clinicaldata**: Clinical data standards
+- **multimodal**: Standards for multimodal data integration
+- **text**: Text data standards and data sets
+- **cloudplatform**: Cloud research platforms
+- **datamodel**: Data models
+- **dataregistry**: Data registries
+- **datavisualization**: Data visualization tools
+- **machinelearningframework**: Machine learning frameworks
+- **eyedata**: Eye data sets
+- **proteindata**: Protein data sets
+- **referencegenome**: Reference genome data
+- **scrnaseqanalysis**: Single-cell RNA sequencing analysis tools
+- **speechdata**: Speech data sets
+
+*Note: This is not an exhaustive list of all available tags.*
+
+## Relationships Between Standards and Topics
+
+Standards and tools in the registry can be related to specific data topics and organizations. These relationships help users identify relevant standards for their specific data domains and connect with responsible organizations. See the page on [topics](topics.md) for more details.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,44 @@
-# b2ai-standards-registry
+# About the Bridge2AI Standards Explorer
 
-This Registry is assembled as part of the [Bridge2AI program](https://bridge2ai.org/). Its overall purpose is to support generation of standardized, interoperable, and machine-readable data from biomedical research.
+The Standards Explorer is part of [**Bridge2AI**](https://bridge2ai.org/), a consortium supported by the National Institute of Health Common Fund. Bridge2AI aims to propel biomedical research forward by setting the stage for widespread adoption of artificial intelligence (AI) that tackles complex biomedical challenges beyond human intuition. See the [official site](https://bridge2ai.org/) or [this NIH page](https://commonfund.nih.gov/bridge2ai) for more details on Bridge2AI.
 
-The Standards Registry contains three main components: the list of standards and tools, the list of use cases, and the collection of associated metadata types (spanning organizations, data topics, and data substrates).
+The Explorer is built and maintained by the [Bridge2AI Standards Working Group](https://bridge2ai.org/standards-practices-and-quality-assessment/). The Standards Working Group is focused on developing strategies to support generation of standardized, interoperable, and machine-readable data from biomedical research.
 
-Data objects are defined according to the [standards-schemas](https://github.com/bridge2ai/standards-schemas).
+## What is the Explorer for?
+
+The Explorer serves as an integrated knowledge base about data standards and the process of preparing data to be AI ready.
+
+Rather than simply listing standards, however, the Explorer displays relevance of each standard to:
+* The groups using it within the Bridge2AI Consortium
+* Its relevant topics and data structures
+* The organization(s) responsible for its creation and continued development
+and other features pertinent to using the standard in practice.
+
+Biomedical researchers may use the Explorer to rapidly determine relevance of a set of standards to their own needs while also seeing examples of how those standards have already been used in Bridge2AI projects.
+
+Computational scientists and AI engineers may use the Explorer to learn about standards and practices used within specific domains of biomedicine, allowing them to better understand the structure and content of biomedical data.
+
+Organizations and individuals planning to develop new methods for ensuring AI data readiness will also find the Explorer useful for characterizing the current standards ecosystem.
+
+## What is in the Explorer?
+
+The Explorer includes six primary types of objects, as described in the table below. Each object has a numerical identifier with a prefix defining its type (e.g., `B2AI_STANDARD:221` refers to a single standard).
+
+| Type | Prefix | Description |
+|-----------|------------|----|
+|**Data Standards and Tools**| `B2AI_STANDARD` | Defined broadly, to include any formal or informal guidelines used to standardize, integrate, or otherwise make data more consistent in structure and content. It covers data standards, ontologies, controlled vocabularies, repositories, other registries, reference implementations, example datasets, software, and relevant training programs. See the page on [categories](categories.md) for more details about specific types of data standards and tools as used in the Explorer.
+|**Data Sets**| `B2AI_DATA` | Data sets produced by Bridge2AI Grand Challenges.
+|**Data Substrates**| `B2AI_SUBSTRATE` | A conceptual category of the structure and content of data itself. This may be interpreted as "data, in this form or format", as compared to a data standard, which refers to the set of rules defining how data is to be organized. For example, `B2AI_SUBSTRATE:9`, or Database, refers to any "organized collection of structured information, stored electronically and organized for rapid search and retrieval." Standards may define or implement specific types of Databases. Similarly, `B2AI_SUBSTRATE:11`, or DICOM, refers to images and metadata stored according to DICOM standards (`B2AI_STANDARD:98`).
+|**Data Topics**| `B2AI_TOPIC` | An area of study or research focus, from the very broad (`B2AI_TOPIC:5` or Data; all Topics in the Explorer are a subclass of this) to the more specific (`B2AI_TOPIC:47` or Respiratory Disorders). These topics also include general methodologies and data collection mechanisms (e.g., `B2AI_TOPIC:38` or Glucose Monitoring).
+|**Organizations**| `B2AI_ORG` | An organization related to or responsible for one or more standards. This includes all Bridge2AI Grand Challenge research groups.
+|**Use Cases**| `B2AI_USECASE` | Specific use cases for standards, including standards for their expected input and outputs.
+
+
+## Where does the data in the Explorer come from?
+
+All data in the Explorer is stored in the [Standards Registry GitHub repository](https://github.com/bridge2ai/b2ai-standards-registry).
+
+## How are standards selected?
 
 The standards in the registry fall into three categories:
 
@@ -14,8 +48,19 @@ The standards in the registry fall into three categories:
 
 Where possible, existing standards are used to inform data element selection. The Registry also includes records for standards outside the scope of data modeling, such as specifications for preferred file formats, exchange protocols, and common APIs.
 
-Our Standards Registry goals are threefold:
+## Why does the Explorer list other resources, like data sets and tools?
 
-1. Ensure integration of the standards development lifecycle within the context of B2AI activities.
-2. Narrow the large space of standards to what is relevant.
-3. Provide computational access and utilities for schemas and standards, rather than links to often outdated PDFs.
+## How may a standard be added or updated?
+
+## Is there a schema or data model for the Explorer?
+
+Data objects are defined according to the [standards-schemas](https://github.com/bridge2ai/standards-schemas).
+
+The Standards Registry contains three main components: the list of standards and tools, the list of use cases, and the collection of associated metadata types (spanning organizations, data topics, and data substrates).
+
+# What do the categories mean?
+
+See the page on 
+
+# What do the topics mean?
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,34 +33,67 @@ The Explorer includes six primary types of objects, as described in the table be
 |**Organizations**| `B2AI_ORG` | An organization related to or responsible for one or more standards. This includes all Bridge2AI Grand Challenge research groups.
 |**Use Cases**| `B2AI_USECASE` | Specific use cases for standards, including standards for their expected input and outputs.
 
+## How are standards selected?
 
-## Where does the data in the Explorer come from?
+Standards in the Explorer are curated by Bridge2AI standards members. All standards, tools, and related resources (see the description of **Data Standards and Tools** above) meeting any of the following criteria are within the scope of curation:
+
+1. Those used or developed by Bridge2AI Grand Challenges.
+2. Those used more generally in biomedical data science and biological research, to characterize the broader environment of data standards.
+3. Those used in specific domains of biomedicine and biology shared by Bridge2AI Grand Challenges (e.g., ophthalmic imaging).
+4. Those used with data for testing, training, and validating artificial intelligence models.
+
+### Why does the Explorer list other resources, like data sets and tools?
+
+Data sets, including both those produced by Bridge2AI Grand Challenges and those categorized as Reference Data or Dataset in the Explorer, serve numerous roles in the production of AI ready data. They:
+* Provide examples of how data has been and is currently released
+* Serve as validation sets for new methods
+* Offer opportunities for comparing new data with previous observations
+
+In addition to the criteria used for curating standards (see above), reference data, software, and other resources are included in the Explorer if they meet one of the following criteria:
+* They are accompanied by standardized metadata and serve as a real-world example of that standard (e.g., [B2AI_STANDARD:690](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:690) is a Datasheet for a text data set; the corresponding standard is [B2AI_STANDARD:326](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:326), or Datasheets)
+* They are very similar to data produced by Bridge2AI Grand Challenges and serve as examples of how data may have been standardized in the past. 
+* They are the origin of a standard (e.g., [B2AI_STANDARD:202](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:202) refers to the WFDB Format, while [B2AI_STANDARD:643](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:643) refers to the WFDB database).
+* They are in broad use within biomedical research, to the point of acting as a standard or a source of standardization.
+
+### Is the Explorer intended to be fully comprehensive?
+
+No. Assembling a complete collection of all standards used for all types of data may not be feasible or even possible. Instead, we have focused on resources relevant to preparing AI ready biomedical and biological data, while also capturing a broader context of the data standards landscape.
+
+### Does the Explorer include only formal, mature standards?
+
+No. Standards development organizations such as the International Organization for Standardization (ISO) play crucial roles in the refinement of expert-designed, formal rules for representing data (e.g., the [ISO 8601 standard](https://www.iso.org/iso-8601-date-and-time-format.html) defines a standardized format for representing date and time). Biomedical research, however, is built upon an assortment of standards varying in formality, maturity, and domain-specificity. Novel methods and approaches may require adaptation or extension of existing standards. Researchers may pursue approaches with few community-tested standards, as evidenced by our Bridge2AI Grand Challenges:
+
+* The **Salutogenesis Grand Challenge** (also known as AI-READI) performed vision assessments with several diagnostic methods. For one method, autorefraction, no single standard existed to capture all metadata they wished to record, so AI-READI researchers [defined and documented an appropriate metadata format](https://docs.aireadi.org/docs/2/dataset/clinical-data/vision-assessment#autorefractor). They also found that, in the collection of Optical Coherence Tomography (OCT) images, several metadata fields defined by the DICOM standard could be safely removed as they either contained patient information or were inconsistent across imaging devices (see [dataset documentation on retinal OCT](https://docs.aireadi.org/docs/2/dataset/retinal-oct/)).
+* The **Precision Public Health Grand Challenge** (also known as Voice as a Biomarker of Health) found that existing protocols for collecting and representing human voice recordings were highly variable and non-standard. No mature standard existed for representing voice recordings along with their relevant features and health information, nor did one for sharing recordings while preserving patient privacy (see more details in [this paper by Bensoussan et al.](https://www.isca-archive.org/interspeech_2024/bensoussan24_interspeech.html)).
+
+## Where is Explorer data stored?
 
 All data in the Explorer is stored in the [Standards Registry GitHub repository](https://github.com/bridge2ai/b2ai-standards-registry).
 
-## How are standards selected?
+The "source of truth" for each table is stored in [YAML](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:393) format in the directory [src/data/](https://github.com/bridge2ai/b2ai-standards-registry/tree/main/src/data).
 
-The standards in the registry fall into three categories:
-
-1. Standards for structuring data used for testing, training, and validating AI models (e.g., genomics file formats and standards for EHR data such as FHIR, OMOP, and ISO).
-2. Standards for describing specific datasets.
-3. Standards for describing machine learning models themselves.
-
-Where possible, existing standards are used to inform data element selection. The Registry also includes records for standards outside the scope of data modeling, such as specifications for preferred file formats, exchange protocols, and common APIs.
-
-## Why does the Explorer list other resources, like data sets and tools?
+Corresponding versions of the tables are provided in JSON and TSV format in the directory [project/data/](https://github.com/bridge2ai/b2ai-standards-registry/tree/main/project/data).
 
 ## How may a standard be added or updated?
+
+To submit a new data standard or other entry to the Explorer (including data topics, organizations, or others), please open an issue on the Standards Registry GitHub repository using [this form](https://github.com/bridge2ai/b2ai-standards-registry/issues/new?template=newEntity.yml).
+
+Updates may also be requested through an issue on the same repository.
 
 ## Is there a schema or data model for the Explorer?
 
 Data objects are defined according to the [standards-schemas](https://github.com/bridge2ai/standards-schemas).
 
-The Standards Registry contains three main components: the list of standards and tools, the list of use cases, and the collection of associated metadata types (spanning organizations, data topics, and data substrates).
+This data model is defined in the [LinkML modeling language](https://linkml.io/).
 
-# What do the categories mean?
+In this repository, schema modules are stored in the [src/standards_schemas/schema/](https://github.com/bridge2ai/standards-schemas/tree/main/src/standards_schemas/schema) directory.
 
-See the page on 
+The schemas are also provided in JSON-LD, [JSONSchema](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:345), and [OWL](https://b2ai.standards.synapse.org/Explore/Standard/DetailsPage?id=B2AI_STANDARD:388) formats within the [project/](https://github.com/bridge2ai/standards-schemas/tree/main/project) directory.
 
-# What do the topics mean?
+## What do the categories mean?
 
+See the page on [categories](categories.md).
+
+## What do the topics mean?
+
+See the page on [topics](topics.md).

--- a/docs/topics.md
+++ b/docs/topics.md
@@ -1,0 +1,62 @@
+# Topics in the Bridge2AI Standards Explorer
+
+The following topics are used in the Explorer:
+
+## Topic Hierarchy
+
+This hierarchy represents the topics used in the Bridge2AI Standards Explorer based on their subclass relationships:
+
+- [Data](topics/Data.markdown)
+  - [Biology](topics/Biology.markdown)
+    - [Molecular Biology](topics/MolecularBiology.markdown)
+      - [Omics](topics/Omics.markdown)
+        - [Genome](topics/Genome.markdown)
+          - [Gene](topics/Gene.markdown)
+            - [Variant](topics/Variant.markdown)
+        - [Proteome](topics/Proteome.markdown)
+          - [Protein](topics/Protein.markdown)
+            - [Protein Structure Model](topics/ProteinStructureModel.markdown)
+        - [Transcriptome](topics/Transcriptome.markdown)
+          - [Transcript](topics/Transcript.markdown)
+        - [Metabolome](topics/Metabolome.markdown)
+    - [Cell](topics/Cell.markdown)
+      - [Neuron](topics/Neuron.markdown)
+      - [Cardiomyocyte](topics/Cardiomyocyte.markdown)
+    - [Respiration](topics/Respiration.markdown)
+  - [Clinical Observations](topics/ClinicalObservations.markdown)
+    - [EHR](topics/EHR.markdown)
+    - [Neurology](topics/Neurology.markdown)
+      - [Neurological Disorders](topics/NeurologicalDisorders.markdown)
+    - [Psychiatry](topics/Psychiatry.markdown)
+      - [Psychiatric Disorders](topics/PsychiatricDisorders.markdown)
+  - [Cheminformatics](topics/Cheminformatics.markdown)
+    - [Drug](topics/Drug.markdown)
+  - [Demographics](topics/Demographics.markdown)
+    - [SDoH](topics/SDoH.markdown)
+  - [Disease](topics/Disease.markdown)
+    - [Eye Diseases](topics/EyeDiseases.markdown)
+    - [Diabetes](topics/Diabetes.markdown)
+    - [Respiratory Disorders](topics/RespiratoryDisorders.markdown)
+    - [Voice Disorders](topics/VoiceDisorders.markdown)
+  - [Environment](topics/Environment.markdown)
+  - [Geolocation](topics/Geolocation.markdown)
+  - [Governance](topics/Governance.markdown)
+  - [Image](topics/Image.markdown)
+    - [Microscale Imaging](topics/MicroscaleImaging.markdown)
+    - [Neurologic Imaging](topics/NeurologicImaging.markdown)
+    - [Ophthalmic Imaging](topics/OphthalmicImaging.markdown)
+  - [mHealth](topics/mHealth.markdown)
+    - [Activity Monitoring](topics/ActivityMonitoring.markdown)
+    - [Glucose Monitoring](topics/GlucoseMonitoring.markdown)
+  - [Networks And Pathways](topics/NetworksAndPathways.markdown)
+  - [Phenotype](topics/Phenotype.markdown)
+  - [Text](topics/Text.markdown)
+    - [Literature](topics/Literature.markdown)
+    - [Social Media](topics/SocialMedia.markdown)
+  - [Survey](topics/Survey.markdown)
+  - [Waveform](topics/Waveform.markdown)
+    - [EKG](topics/EKG.markdown)
+    - [Voice](topics/Voice.markdown)
+
+This hierarchy represents the relationships between topics as defined in the Bridge2AI Standards Registry.
+

--- a/docs/topics.md
+++ b/docs/topics.md
@@ -6,57 +6,104 @@ The following topics are used in the Explorer:
 
 This hierarchy represents the topics used in the Bridge2AI Standards Explorer based on their subclass relationships:
 
-- [Data](topics/Data.markdown)
-  - [Biology](topics/Biology.markdown)
-    - [Molecular Biology](topics/MolecularBiology.markdown)
-      - [Omics](topics/Omics.markdown)
-        - [Genome](topics/Genome.markdown)
-          - [Gene](topics/Gene.markdown)
-            - [Variant](topics/Variant.markdown)
-        - [Proteome](topics/Proteome.markdown)
-          - [Protein](topics/Protein.markdown)
-            - [Protein Structure Model](topics/ProteinStructureModel.markdown)
-        - [Transcriptome](topics/Transcriptome.markdown)
-          - [Transcript](topics/Transcript.markdown)
-        - [Metabolome](topics/Metabolome.markdown)
-    - [Cell](topics/Cell.markdown)
-      - [Neuron](topics/Neuron.markdown)
-      - [Cardiomyocyte](topics/Cardiomyocyte.markdown)
-    - [Respiration](topics/Respiration.markdown)
-  - [Clinical Observations](topics/ClinicalObservations.markdown)
-    - [EHR](topics/EHR.markdown)
-    - [Neurology](topics/Neurology.markdown)
-      - [Neurological Disorders](topics/NeurologicalDisorders.markdown)
-    - [Psychiatry](topics/Psychiatry.markdown)
-      - [Psychiatric Disorders](topics/PsychiatricDisorders.markdown)
-  - [Cheminformatics](topics/Cheminformatics.markdown)
-    - [Drug](topics/Drug.markdown)
-  - [Demographics](topics/Demographics.markdown)
-    - [SDoH](topics/SDoH.markdown)
-  - [Disease](topics/Disease.markdown)
-    - [Eye Diseases](topics/EyeDiseases.markdown)
-    - [Diabetes](topics/Diabetes.markdown)
-    - [Respiratory Disorders](topics/RespiratoryDisorders.markdown)
-    - [Voice Disorders](topics/VoiceDisorders.markdown)
-  - [Environment](topics/Environment.markdown)
-  - [Geolocation](topics/Geolocation.markdown)
-  - [Governance](topics/Governance.markdown)
-  - [Image](topics/Image.markdown)
-    - [Microscale Imaging](topics/MicroscaleImaging.markdown)
-    - [Neurologic Imaging](topics/NeurologicImaging.markdown)
-    - [Ophthalmic Imaging](topics/OphthalmicImaging.markdown)
-  - [mHealth](topics/mHealth.markdown)
-    - [Activity Monitoring](topics/ActivityMonitoring.markdown)
-    - [Glucose Monitoring](topics/GlucoseMonitoring.markdown)
-  - [Networks And Pathways](topics/NetworksAndPathways.markdown)
-  - [Phenotype](topics/Phenotype.markdown)
-  - [Text](topics/Text.markdown)
-    - [Literature](topics/Literature.markdown)
-    - [Social Media](topics/SocialMedia.markdown)
-  - [Survey](topics/Survey.markdown)
-  - [Waveform](topics/Waveform.markdown)
-    - [EKG](topics/EKG.markdown)
-    - [Voice](topics/Voice.markdown)
 
-This hierarchy represents the relationships between topics as defined in the Bridge2AI Standards Registry.
-
+[Data](topics/Data.markdown)
+├── [Biology](topics/Biology.markdown)
+│   │
+│   ├── [Molecular Biology](topics/MolecularBiology.markdown)
+│   │   │
+│   │   └── [Omics](topics/Omics.markdown)
+│   │       │
+│   │       ├── [Genome](topics/Genome.markdown)
+│   │       │   │
+│   │       │   └── [Gene](topics/Gene.markdown)
+│   │       │       │
+│   │       │       └── [Variant](topics/Variant.markdown)
+│   │       │
+│   │       ├── [Proteome](topics/Proteome.markdown)
+│   │       │   │
+│   │       │   └── [Protein](topics/Protein.markdown)
+│   │       │       │
+│   │       │       └── [Protein Structure Model](topics/ProteinStructureModel.markdown)
+│   │       │
+│   │       ├── [Transcriptome](topics/Transcriptome.markdown)
+│   │       │   │
+│   │       │   └── [Transcript](topics/Transcript.markdown)
+│   │       │
+│   │       └── [Metabolome](topics/Metabolome.markdown)
+│   │
+│   ├── [Cell](topics/Cell.markdown)
+│   │   │
+│   │   ├── [Neuron](topics/Neuron.markdown)
+│   │   │
+│   │   └── [Cardiomyocyte](topics/Cardiomyocyte.markdown)
+│   │
+│   └── [Respiration](topics/Respiration.markdown)
+│
+├── [Clinical Observations](topics/ClinicalObservations.markdown)
+│   │
+│   ├── [EHR](topics/EHR.markdown)
+│   │
+│   ├── [Neurology](topics/Neurology.markdown)
+│   │   │
+│   │   └── [Neurological Disorders](topics/NeurologicalDisorders.markdown)
+│   │
+│   └── [Psychiatry](topics/Psychiatry.markdown)
+│       │
+│       └── [Psychiatric Disorders](topics/PsychiatricDisorders.markdown)
+│
+├── [Cheminformatics](topics/Cheminformatics.markdown)
+│   │
+│   └── [Drug](topics/Drug.markdown)
+│
+├── [Demographics](topics/Demographics.markdown)
+│   │
+│   └── [SDoH](topics/SDoH.markdown)
+│
+├── [Disease](topics/Disease.markdown)
+│   │
+│   ├── [Eye Diseases](topics/EyeDiseases.markdown)
+│   │
+│   ├── [Diabetes](topics/Diabetes.markdown)
+│   │
+│   ├── [Respiratory Disorders](topics/RespiratoryDisorders.markdown)
+│   │
+│   └── [Voice Disorders](topics/VoiceDisorders.markdown)
+│
+├── [Environment](topics/Environment.markdown)
+│
+├── [Geolocation](topics/Geolocation.markdown)
+│
+├── [Governance](topics/Governance.markdown)
+│
+├── [Image](topics/Image.markdown)
+│   │
+│   ├── [Microscale Imaging](topics/MicroscaleImaging.markdown)
+│   │
+│   ├── [Neurologic Imaging](topics/NeurologicImaging.markdown)
+│   │
+│   └── [Ophthalmic Imaging](topics/OphthalmicImaging.markdown)
+│
+├── [mHealth](topics/mHealth.markdown)
+│   │
+│   ├── [Activity Monitoring](topics/ActivityMonitoring.markdown)
+│   │
+│   └── [Glucose Monitoring](topics/GlucoseMonitoring.markdown)
+│
+├── [Networks And Pathways](topics/NetworksAndPathways.markdown)
+│
+├── [Phenotype](topics/Phenotype.markdown)
+│
+├── [Text](topics/Text.markdown)
+│   │
+│   ├── [Literature](topics/Literature.markdown)
+│   │
+│   └── [Social Media](topics/SocialMedia.markdown)
+│
+├── [Survey](topics/Survey.markdown)
+│
+└── [Waveform](topics/Waveform.markdown)
+    │
+    ├── [EKG](topics/EKG.markdown)
+    │
+    └── [Voice](topics/Voice.markdown)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ plugins:
   - search
 nav:
   - Home: index.md
+  - Categories: categories.md
   - Curation: curation.md
   - Standards:
       - All Standards: DataStandardOrTool.markdown
@@ -33,6 +34,7 @@ nav:
   - Substrates:
       - All Substrates: DataSubstrate.markdown
   - Topics:
+      - Topics Overview: topics.md
       - All Topics: DataTopic.markdown
       - Biology: topics/Biology.markdown
       - Cell: topics/Cell.markdown


### PR DESCRIPTION
Adds new docs. These may be used as-is for now but the plan is to move them to the Explorer site when possible.
They include:
* A rewrite of docs/index.md to cover general Explorer rationale, technical processes, and curation guidelines. It's more of an FAQ now.
* A new docs/categories.md describing the differences between the Standards classes
* A new docs/topics.md serving as a tree-like view of the topics. This currently links to individual pages for each topic to avoid overcrowding, but if there is an appropriate Synapse component for this then that would be fantastic