### PR TITLE
Add AI applications and reference publications for standards

### DIFF
--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -15538,7 +15538,23 @@ data_standardortools_collection:
         (WORKS)
     used_in_bridge2ai: false
   publication:
-    ref_url: ''
+    ref_url: https://doi.org/10.1038/sdata.2016.102
+    ref_title: Sharing brain mapping statistical results with the neuroimaging data model
+    ref_authors:
+    - Maumet C
+    - Auer T
+    - Bowring A
+    - Chen G
+    - Das S
+    - Flandin G
+    - Ghosh S
+    - Glatard T
+    - Gorgolewski KJ
+    - Helmer KG
+    - Jenkinson M
+    - Keator DB
+    ref_publication_year: 2016
+    ref_journal: Scientific Data
 - id: B2AI_STANDARD:233
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
@@ -16932,7 +16948,21 @@ data_standardortools_collection:
   - B2AI_ORG:77
   url: https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/#
   publication:
-    ref_url: ''
+    ref_url: https://doi.org/10.1186/gb-2005-6-5-r47
+    ref_title: 'The Open Microscopy Environment (OME) Data Model and XML file: open tools for informatics and quantitative analysis in biological imaging'
+    ref_authors:
+    - Goldberg IG
+    - Allan C
+    - Burel J
+    - Creager D
+    - Falconi A
+    - Hochheiser H
+    - Johnston J
+    - Mellen J
+    - Sorger PK
+    - Swedlow JR
+    ref_publication_year: 2005
+    ref_journal: Genome Biology
 - id: B2AI_STANDARD:248
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
@@ -17993,7 +18023,23 @@ data_standardortools_collection:
       ref_publication_year: 2022
       ref_journal: Nat Biotechnol
   publication:
-    ref_url: ''
+    ref_url: https://doi.org/10.1038/s41587-022-01357-4
+    ref_title: The GA4GH Phenopacket schema defines a computable representation of clinical data
+    ref_authors:
+    - Jacobsen JOB
+    - Baudis M
+    - Baynam GS
+    - Beckmann JS
+    - Beltran S
+    - Buske OJ
+    - Callahan TJ
+    - Chute CG
+    - Courtot M
+    - Danis D
+    - Elemento O
+    - Essenwanger A
+    ref_publication_year: 2022
+    ref_journal: Nature Biotechnology
 - id: B2AI_STANDARD:257
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
@@ -18426,7 +18472,23 @@ data_standardortools_collection:
   - B2AI_ORG:41
   url: https://www.psidev.info/mif
   publication:
-    ref_url: ''
+    ref_url: https://doi.org/10.1038/nbt926
+    ref_title: The HUPO PSI's Molecular Interaction format-a community standard for the representation of protein interaction data
+    ref_authors:
+    - Hermjakob H
+    - Montecchi-Palazzi L
+    - Bader G
+    - Wojcik J
+    - Salwinski L
+    - Ceol A
+    - Moore S
+    - Orchard S
+    - Sarkans U
+    - von Mering C
+    - Roechert B
+    - Poux S
+    ref_publication_year: 2004
+    ref_journal: Nature Biotechnology
 - id: B2AI_STANDARD:267
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
@@ -20596,7 +20658,23 @@ data_standardortools_collection:
       ref_publication_year: 2021
       ref_journal: Genome Biol
   publication:
-    ref_url: ''
+    ref_url: https://doi.org/10.1093/bioinformatics/btr330
+    ref_title: The variant call format and VCFtools
+    ref_authors:
+    - Danecek P
+    - Auton A
+    - Abecasis G
+    - Albers CA
+    - Banks E
+    - DePristo MA
+    - Handsaker RE
+    - Lunter G
+    - Marth GT
+    - Sherry ST
+    - McVean G
+    - Durbin R
+    ref_publication_year: 2011
+    ref_journal: Bioinformatics
 - id: B2AI_STANDARD:300
   category: B2AI_STANDARD:BiomedicalStandard
   collection:


### PR DESCRIPTION
This adds:
* AI applications for MIxS, ReproSchema, protobuf, and RDFS
* Reference publication metadata for 30 entries

It also fixes several duplicated B2AI_APP IDs.