### PR TITLE
Fix improper parsing of Manifest data_parts as STRING_LIST

### DIFF
--- a/scripts/analyze_and_update_synapse_tables.py
+++ b/scripts/analyze_and_update_synapse_tables.py
@@ -52,6 +52,9 @@ DATATYPE_OVERRRIDES = {
     # maybe will only work for JSON cols, which is fine for now
     'DataStandardOrTool': {
         'has_application': ColumnType.JSON
+    },
+    'Manifest': {
+        'data_parts': ColumnType.JSON
     }
 }
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -67,6 +67,16 @@ def infer_column_type(values: pd.Series) -> ColumnType:
     if len(non_empty) == 0:
         return ColumnType.STRING
 
+    # Nested objects must be stored as JSON rather than STRING_LIST.
+    if non_empty.apply(lambda v: isinstance(v, Mapping)).any():
+        return ColumnType.JSON
+
+    nested_list_values = non_empty[non_empty.apply(lambda v: isinstance(v, list))]
+    if not nested_list_values.empty and nested_list_values.apply(
+        lambda items: any(isinstance(item, (Mapping, list)) for item in items)
+    ).any():
+        return ColumnType.JSON
+
     # Check types of non-empty values
     types = non_empty.map(type).unique()
 

--- a/tests/test_analyze_and_update_synapse_tables.py
+++ b/tests/test_analyze_and_update_synapse_tables.py
@@ -1,0 +1,35 @@
+"""Tests for Synapse table update behavior."""
+
+import unittest
+
+import pandas as pd
+from synapseclient.models import ColumnType
+
+from scripts.analyze_and_update_synapse_tables import get_col_defs
+
+
+class GetColDefsTests(unittest.TestCase):
+    """Verify table-specific Synapse schema overrides."""
+
+    def test_get_col_defs_marks_manifest_data_parts_as_json(self):
+        df = pd.DataFrame(
+            [
+                {
+                    "id": "B2AI_MANIFEST:1",
+                    "data_parts": [
+                        {
+                            "data_part_name": "Cell maps",
+                            "standards_and_tools": ["B2AI_STANDARD:372"],
+                        }
+                    ],
+                }
+            ]
+        )
+
+        coldefs = {col.name: col for col in get_col_defs(df, "Manifest")}
+
+        self.assertEqual(coldefs["data_parts"].column_type, ColumnType.JSON)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+"""Tests for utility helpers used by Synapse upload scripts."""
+
+import unittest
+
+import pandas as pd
+from synapseclient.models import ColumnType
+
+from scripts.utils import infer_column_type
+
+
+class InferColumnTypeTests(unittest.TestCase):
+    """Verify Synapse column type inference for nested values."""
+
+    def test_infer_column_type_returns_json_for_dict_values(self):
+        values = pd.Series([{"name": "alpha"}, {"name": "beta"}, None, ""])
+
+        self.assertEqual(infer_column_type(values), ColumnType.JSON)
+
+    def test_infer_column_type_returns_json_for_list_of_dicts(self):
+        values = pd.Series([
+            [{"data_part_name": "Cell maps"}],
+            [{"data_part_name": "Evidence"}],
+            [],
+        ])
+
+        self.assertEqual(infer_column_type(values), ColumnType.JSON)
+
+    def test_infer_column_type_keeps_string_lists_as_string_list(self):
+        values = pd.Series([["alpha", "beta"], ["gamma"], []])
+
+        self.assertEqual(infer_column_type(values), ColumnType.STRING_LIST)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request improves how Synapse table schemas are generated and inferred, especially for columns containing nested data structures. It introduces logic to ensure columns with nested dictionaries or lists are correctly typed as JSON, and adds tests to verify these behaviors.

**Schema inference and overrides:**

* Updated `infer_column_type` in `scripts/utils.py` to return `ColumnType.JSON` for columns containing nested dictionaries or lists, ensuring proper handling of complex data structures.
* Added a schema override for the `Manifest` table in `scripts/analyze_and_update_synapse_tables.py`, specifying that the `data_parts` column should be stored as JSON.

**Testing improvements:**

* Added `tests/test_utils.py` to verify that `infer_column_type` returns the correct column type for nested dicts, lists of dicts, and simple string lists.
* Added `tests/test_analyze_and_update_synapse_tables.py` to ensure the `Manifest.data_parts` column is marked as JSON in the generated schema.