### PR TITLE
Curate concerns_data_topic annotations in DataStandardOrTool

### DIFF
--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -51986,7 +51986,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1136
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -52005,7 +52005,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1137
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -35766,7 +35766,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:735
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -36327,7 +36327,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:754
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -38860,7 +38860,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:797
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39299,7 +39299,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:801
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39795,7 +39795,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:815
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -36392,7 +36392,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -36957,7 +36957,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -37877,7 +37877,7 @@ data_standardortools_collection:
   collection:
   - notebookplatform
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -38147,7 +38147,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -38714,7 +38714,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -1355,7 +1355,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:23
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - B2AI_TOPIC:54
+  - fileformat
   concerns_data_topic:
   - B2AI_TOPIC:12
   contributor_github_name: caufieldjh
@@ -4121,7 +4121,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:58
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - B2AI_TOPIC:54
+  - fileformat
   concerns_data_topic:
   - B2AI_TOPIC:12
   - B2AI_TOPIC:26
@@ -4855,7 +4855,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:67
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - B2AI_TOPIC:54
+  - guidelines
   concerns_data_topic:
   - B2AI_TOPIC:4
   contributor_github_name: caufieldjh
@@ -5013,7 +5013,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:70
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - B2AI_TOPIC:54
+  - guidelines
   concerns_data_topic:
   - B2AI_TOPIC:18
   contributor_github_name: caufieldjh
@@ -5214,7 +5214,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:71
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
-  - B2AI_TOPIC:54
+  - B2AI_TOPIC:9
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -35215,7 +35215,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -35402,7 +35402,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:727
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -35492,7 +35492,7 @@ data_standardortools_collection:
   - datavisualization
   - notebookplatform
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -35732,7 +35732,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:734
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -35938,7 +35938,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:740
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -42555,7 +42555,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -43034,7 +43034,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:861
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contribution_date: '2023-03-24'
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -43068,7 +43068,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:862
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contribution_date: '2023-03-27'
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -43367,7 +43367,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:871
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contribution_date: '2023-06-20'
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -49709,7 +49709,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1037
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -49905,7 +49905,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1044
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50081,7 +50081,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1054
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50271,7 +50271,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1065
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50487,7 +50487,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1078
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50754,7 +50754,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1094
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -1474,7 +1474,8 @@ data_standardortools_collection:
   collection:
   - datamodel
   concerns_data_topic:
-  - B2AI_TOPIC:20
+  - B2AI_TOPIC:53
+  - B2AI_TOPIC:21
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -8666,6 +8667,7 @@ data_standardortools_collection:
   - standards_process_maturity_final
   - implementation_maturity_production
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:9
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -15211,6 +15213,7 @@ data_standardortools_collection:
   - guidelines
   concerns_data_topic:
   - B2AI_TOPIC:4
+  - B2AI_TOPIC:40
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -33500,6 +33503,7 @@ data_standardortools_collection:
   collection:
   - obofoundry
   concerns_data_topic:
+  - B2AI_TOPIC:53
   - B2AI_TOPIC:12
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -43744,6 +43748,7 @@ data_standardortools_collection:
   - guidelines
   concerns_data_topic:
   - B2AI_TOPIC:15
+  - B2AI_TOPIC:54
   contribution_date: '2023-12-06'
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -40431,7 +40431,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:825
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -40601,7 +40601,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -42251,7 +42251,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:833
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -42276,7 +42276,7 @@ data_standardortools_collection:
   - deprecated
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -42426,7 +42426,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -48233,7 +48233,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:959
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48250,7 +48250,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:960
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48269,7 +48269,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:961
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48305,7 +48305,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:963
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48794,7 +48794,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:990
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -1355,7 +1355,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:23
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - fileformat
+  - B2AI_TOPIC:54
   concerns_data_topic:
   - B2AI_TOPIC:12
   contributor_github_name: caufieldjh
@@ -4121,7 +4121,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:58
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - fileformat
+  - B2AI_TOPIC:54
   concerns_data_topic:
   - B2AI_TOPIC:12
   - B2AI_TOPIC:26
@@ -4855,7 +4855,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:67
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - guidelines
+  - B2AI_TOPIC:54
   concerns_data_topic:
   - B2AI_TOPIC:4
   contributor_github_name: caufieldjh
@@ -5013,7 +5013,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:70
   category: B2AI_STANDARD:BiomedicalStandard
   collection:
-  - guidelines
+  - B2AI_TOPIC:54
   concerns_data_topic:
   - B2AI_TOPIC:18
   contributor_github_name: caufieldjh
@@ -5214,7 +5214,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:71
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
-  - B2AI_TOPIC:9
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -49731,7 +49731,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1038
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -3007,6 +3007,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:40
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:4
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -19033,6 +19034,7 @@ data_standardortools_collection:
   collection:
   - datamodel
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:12
   - B2AI_TOPIC:33
   contributor_github_name: caufieldjh
@@ -22682,6 +22684,7 @@ data_standardortools_collection:
   - codesystem
   concerns_data_topic:
   - B2AI_TOPIC:6
+  - B2AI_TOPIC:14
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48753,7 +48756,8 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:987
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:9
+  - B2AI_TOPIC:52
+  - B2AI_TOPIC:31
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -49456,6 +49460,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1025
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
+  - B2AI_TOPIC:52
   - B2AI_TOPIC:53
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -50056,6 +50061,8 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1052
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
+  - B2AI_TOPIC:52
+  - B2AI_TOPIC:53
   - B2AI_TOPIC:3
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -47512,7 +47512,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:921
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -48864,7 +48864,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:994
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -49077,7 +49077,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1006
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -49145,7 +49145,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1011
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -49884,7 +49884,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1043
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -8919,6 +8919,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:118
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:9
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -13036,7 +13037,7 @@ data_standardortools_collection:
   collection:
   - fileformat
   concerns_data_topic:
-  - B2AI_TOPIC:33
+  - B2AI_TOPIC:34
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831'
@@ -16875,6 +16876,7 @@ data_standardortools_collection:
   collection:
   - fileformat
   concerns_data_topic:
+  - B2AI_TOPIC:53
   - B2AI_TOPIC:1
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -17064,6 +17066,7 @@ data_standardortools_collection:
   collection:
   - fileformat
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:19
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -18280,6 +18283,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:260
   category: B2AI_STANDARD:BiomedicalStandard
   concerns_data_topic:
+  - B2AI_TOPIC:54
   - B2AI_TOPIC:1
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
@@ -50727,6 +50731,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1092
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
+  - B2AI_TOPIC:52
   - B2AI_TOPIC:33
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -50869,7 +50869,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1101
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50885,7 +50885,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1102
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -50949,7 +50949,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1106
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -51079,7 +51079,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1113
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -51965,7 +51965,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:1135
   category: B2AI_STANDARD:TrainingProgram
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:52
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -35253,7 +35253,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -36719,7 +36719,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -37085,7 +37085,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -38589,7 +38589,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -38640,7 +38640,7 @@ data_standardortools_collection:
   collection:
   - cloudservice
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831

--- a/src/data/DataStandardOrTool.yaml
+++ b/src/data/DataStandardOrTool.yaml
@@ -39756,7 +39756,7 @@ data_standardortools_collection:
 - id: B2AI_STANDARD:813
   category: B2AI_STANDARD:SoftwareOrTool
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39777,7 +39777,7 @@ data_standardortools_collection:
   collection:
   - datavisualization
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39817,7 +39817,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39878,7 +39878,7 @@ data_standardortools_collection:
   collection:
   - notebookplatform
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831
@@ -39939,7 +39939,7 @@ data_standardortools_collection:
   collection:
   - machinelearningframework
   concerns_data_topic:
-  - B2AI_TOPIC:5
+  - B2AI_TOPIC:54
   contributor_github_name: caufieldjh
   contributor_name: Harry Caufield
   contributor_orcid: ORCID:0000-0001-5705-7831


### PR DESCRIPTION
## Summary
This PR performs iterative metadata curation for topic annotations in src/data/DataStandardOrTool.yaml.

## What was done
- Created a dedicated curation branch and curated concerns_data_topic values in multiple committed batches.
- Replaced broad/general topic usage (especially B2AI_TOPIC:5) with more specific topics defined in src/data/DataTopic.yaml.
- Completed full pass for remaining SoftwareOrTool entries that still used B2AI_TOPIC:5.
- Performed additional random-sample refinement passes to improve topic specificity across mixed categories (BiomedicalStandard, DataStandard, OntologyOrVocabulary, TrainingProgram).
- Fixed one intermediate unintended patch effect and committed the correction before continuing curation.

## Scope
- File changed: src/data/DataStandardOrTool.yaml
- No code/API behavior changes; metadata curation only.

## Validation
- YAML parsing was re-checked after each batch using yaml.safe_load and remained valid.

## Notes
- Work was intentionally committed in small batches to preserve reviewability and traceability of curation decisions.
